### PR TITLE
Add capacity to define compound indexes

### DIFF
--- a/source/middleware/models.js
+++ b/source/middleware/models.js
@@ -79,6 +79,12 @@ module.exports = function (service, connection, modelsPath) {
 				}
 			}
 
+			if (params.indexes) {
+				for (const m of params.indexes) {
+					schema.index(...m);
+				}
+			}
+
 			if (params.plugins) {
 				for (let p in params.plugins) {
 					schema.plugin(params.plugins[p]);


### PR DESCRIPTION
In the model you can add something like this to define compound indexes:

```javascript
	indexes    : [
		[{ field_one: 1, field_two : 1 }, { unique : true }],
	],
```